### PR TITLE
#2 Change a TODO state

### DIFF
--- a/src/app/todos/components/todo-table/todo-table.component.html
+++ b/src/app/todos/components/todo-table/todo-table.component.html
@@ -12,8 +12,16 @@
     </button>
   </div> -->
   
-  <ng-container class="todoList">  
+  <div>
+  <button mat-raised-button (click)="sortToDoListByStatus()">
+    Trier
+  </button>
+  </div>
+
+  <ng-container class="todoList">
+
     <table mat-table [dataSource]="todos">
+
       <!-- Title Column -->
       <ng-container matColumnDef="title">
         <th mat-header-cell *matHeaderCellDef>Tâche</th>
@@ -25,10 +33,24 @@
         <th mat-header-cell *matHeaderCellDef>Statut</th>
         <td mat-cell *matCellDef="let todo">{{todo.statusType | replace}}</td>
       </ng-container>
+
+      <!-- Checkbox Column -->
+      <ng-container matColumnDef="select">
+        <th mat-header-cell *matHeaderCellDef>
+        </th>
+        <td mat-cell *matCellDef="let todo">
+          <mat-checkbox (click)="$event.stopPropagation()"
+                        (change)="onTodoToggled(todo)"
+                        [checked]="selection.isSelected(todo)">
+          </mat-checkbox>
+        </td>
+      </ng-container>
     
       <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+
     </table>
+    
     </ng-container>
   
   <!-- <mat-card class="mat-card mat-elevation-z4" *ngFor="let todo of todoList">

--- a/src/app/todos/components/todo-table/todo-table.component.ts
+++ b/src/app/todos/components/todo-table/todo-table.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { TodoDto } from '../../dto/todo-dto';
 import { MatTableDataSource } from '@angular/material/table';
 import { TodosService } from '../../service/todos.service';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
+import { SelectionModel } from '@angular/cdk/collections';
 
 @Component({
   selector: 'app-todo-table',
@@ -15,7 +16,8 @@ export class TodoTableComponent implements OnInit{
 
   todos!: TodoDto[];
   todo: TodoDto = new TodoDto();
-  displayedColumns: string[] = ['title', 'status'];
+  displayedColumns: string[] = ['title', 'status', 'select'];
+  selection = new SelectionModel<TodoDto>(true, []);
 
   constructor (private todosService: TodosService,
     private router: Router) {}
@@ -25,5 +27,21 @@ export class TodoTableComponent implements OnInit{
       console.log(data);
       this.todos = data.datas.todos;
     });
+  }
+
+  sortToDoListByStatus() {
+    this.todos.sort((a, b) => b.statusType.localeCompare(a.statusType));
+    console.log(this.todos);
+  }
+
+  onTodoToggled(todo : TodoDto) {
+    this.selection.toggle(todo);
+    const selectedTodo = this.selection.selected;
+    selectedTodo.forEach( row => {
+      row.statusType = "Done";
+      //row.title = row.title.strike();
+    }
+    )
+    console.log(selectedTodo);
   }
 }


### PR DESCRIPTION
Utilisation de Material UI <mat-checkbox>
Utilisation de SelectionModel
Changement de statut dans la méthode onTodoToggled (méthode strike à améliorer)
Rajout d’un bouton pour trier les les todos en fonction de leurs statuts (marche mais ne s’affiche pas dans le template)
Solutions possibles : Implémenter Sort ou créer un observable.
Amélioration : Reset le statusType en décochant la checkbox
